### PR TITLE
Assignment2 Kasey & Ben

### DIFF
--- a/Logger.Tests/BaseLoggerMixinsTests.cs
+++ b/Logger.Tests/BaseLoggerMixinsTests.cs
@@ -14,7 +14,7 @@ public class BaseLoggerMixinsTests
         // Arrange
 
         // Act
-        //BaseLoggerMixins.Error(null, "");
+        BaseLoggerMixins.Error(null, "");
 
         // Assert
     }

--- a/Logger.Tests/BaseLoggerMixinsTests.cs
+++ b/Logger.Tests/BaseLoggerMixinsTests.cs
@@ -8,13 +8,49 @@ namespace Logger.Tests;
 public class BaseLoggerMixinsTests
 {
     [TestMethod]
+    //figure out how to do data rows
     [ExpectedException(typeof(ArgumentNullException))]
     public void Error_WithNullLogger_ThrowsException()
     {
         // Arrange
-
         // Act
         BaseLoggerMixins.Error(null, "");
+
+        // Assert
+        Assert.ThrowsException<ArgumentNullException>(() => BaseLoggerMixins.Error(null, ""));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void Warning_WithNullLogger_ThrowsException()
+    {
+        // Arrange
+        // Act
+        BaseLoggerMixins.Warning(null, "");
+
+        // Assert
+        Assert.ThrowsException<ArgumentNullException>(() => BaseLoggerMixins.Error(null, ""));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void Information_WithNullLogger_ThrowsException()
+    {
+        // Arrange
+        // Act
+        BaseLoggerMixins.Information(null, "");
+
+        // Assert
+        Assert.ThrowsException<ArgumentNullException>(() => BaseLoggerMixins.Error(null, ""));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void Debug_WithNullLogger_ThrowsException()
+    {
+        // Arrange
+        // Act
+        BaseLoggerMixins.Debug(null, "");
 
         // Assert
         Assert.ThrowsException<ArgumentNullException>(() => BaseLoggerMixins.Error(null, ""));
@@ -32,6 +68,51 @@ public class BaseLoggerMixinsTests
         // Assert
         Assert.AreEqual(1, logger.LoggedMessages.Count);
         Assert.AreEqual(LogLevel.Error, logger.LoggedMessages[0].LogLevel);
+        Assert.AreEqual("Message 42", logger.LoggedMessages[0].Message);
+    }
+
+    [TestMethod]
+    public void Warning_WithData_LogsMessage()
+    {
+        // Arrange
+        var logger = new TestLogger();
+
+        // Act
+        logger.Warning("Message {0}", 42);
+
+        // Assert
+        Assert.AreEqual(1, logger.LoggedMessages.Count);
+        Assert.AreEqual(LogLevel.Warning, logger.LoggedMessages[0].LogLevel);
+        Assert.AreEqual("Message 42", logger.LoggedMessages[0].Message);
+    }
+
+    [TestMethod]
+    public void Information_WithData_LogsMessage()
+    {
+        // Arrange
+        var logger = new TestLogger();
+
+        // Act
+        logger.Information("Message {0}", 42);
+
+        // Assert
+        Assert.AreEqual(1, logger.LoggedMessages.Count);
+        Assert.AreEqual(LogLevel.Information, logger.LoggedMessages[0].LogLevel);
+        Assert.AreEqual("Message 42", logger.LoggedMessages[0].Message);
+    }
+
+    [TestMethod]
+    public void Debug_WithData_LogsMessage()
+    {
+        // Arrange
+        var logger = new TestLogger();
+
+        // Act
+        logger.Debug("Message {0}", 42);
+
+        // Assert
+        Assert.AreEqual(1, logger.LoggedMessages.Count);
+        Assert.AreEqual(LogLevel.Debug, logger.LoggedMessages[0].LogLevel);
         Assert.AreEqual("Message 42", logger.LoggedMessages[0].Message);
     }
 

--- a/Logger.Tests/BaseLoggerMixinsTests.cs
+++ b/Logger.Tests/BaseLoggerMixinsTests.cs
@@ -11,7 +11,7 @@ public class BaseLoggerMixinsTests
     [TestMethod]
     //figure out how to do data rows
     [ExpectedException(typeof(ArgumentNullException))]
-    public void Error_WithNullLogger_ThrowsException(LogLevel logLevel)
+    public void Error_WithNullLogger_ThrowsException()
     {
         // Arrange
         // Act

--- a/Logger.Tests/BaseLoggerMixinsTests.cs
+++ b/Logger.Tests/BaseLoggerMixinsTests.cs
@@ -17,7 +17,7 @@ public class BaseLoggerMixinsTests
         BaseLoggerMixins.Error(null, "");
 
         // Assert
-        Assert.ThrowsException<ArgumentNullException>(() => BaseLoggerMixins.Error(null, "", string));
+        Assert.ThrowsException<ArgumentNullException>(() => BaseLoggerMixins.Error(null, ""));
     }
 
     [TestMethod]

--- a/Logger.Tests/BaseLoggerMixinsTests.cs
+++ b/Logger.Tests/BaseLoggerMixinsTests.cs
@@ -17,6 +17,7 @@ public class BaseLoggerMixinsTests
         BaseLoggerMixins.Error(null, "");
 
         // Assert
+        Assert.ThrowsException<ArgumentNullException>(() => BaseLoggerMixins.Error(null, "", string));
     }
 
     [TestMethod]
@@ -26,7 +27,7 @@ public class BaseLoggerMixinsTests
         var logger = new TestLogger();
 
         // Act
-        //logger.Error("Message {0}", 42);
+        logger.Error("Message {0}", 42);
 
         // Assert
         Assert.AreEqual(1, logger.LoggedMessages.Count);

--- a/Logger.Tests/BaseLoggerMixinsTests.cs
+++ b/Logger.Tests/BaseLoggerMixinsTests.cs
@@ -7,10 +7,11 @@ namespace Logger.Tests;
 [TestClass]
 public class BaseLoggerMixinsTests
 {
+
     [TestMethod]
     //figure out how to do data rows
     [ExpectedException(typeof(ArgumentNullException))]
-    public void Error_WithNullLogger_ThrowsException()
+    public void Error_WithNullLogger_ThrowsException(LogLevel logLevel)
     {
         // Arrange
         // Act

--- a/Logger.Tests/FileLoggerTests.cs
+++ b/Logger.Tests/FileLoggerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 
 using System;
 using System.IO;
@@ -28,12 +29,10 @@ public class FileLoggerTests
     
 
     }
-    [TestMethod]
-    public void CreateLogger_CreateLogger_Sucess() 
-    {
-        //arrange
-        
-        
-    
-    }
+    //[TestMethod]
+    //public string
+
+
+
+  
 }

--- a/Logger.Tests/FileLoggerTests.cs
+++ b/Logger.Tests/FileLoggerTests.cs
@@ -48,7 +48,7 @@ public class FileLoggerTests
     public void Log_AppendMessageInFile()
     {
         //arrange
-        var fileLogger = new FileLogger(_logFilePath);
+        var fileLogger = new FileLogger(_logFilePath, "testClass");
         string testMessage = "Test message";
 
         //act
@@ -56,6 +56,8 @@ public class FileLoggerTests
         var logMessage = File.ReadAllText(_logFilePath);
         //
         Assert.IsTrue(logMessage.Contains(testMessage));
+        Assert.IsTrue(logMessage.Contains("Information"));
+        Assert.IsTrue(logMessage.Contains("testClass"));
         
     }
 

--- a/Logger.Tests/FileLoggerTests.cs
+++ b/Logger.Tests/FileLoggerTests.cs
@@ -1,9 +1,39 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using System;
+using System.IO;
+using System.Reflection;
+
 namespace Logger.Tests;
+
+
 
 [TestClass]
 public class FileLoggerTests
 {
+    private string _logFilePath = string.Empty;
 
+    [TestInitialize]
+    public void Setup()
+    {
+        //set up loog file path
+        string assemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
+        _logFilePath = Path.Combine(assemblyPath, "testlog.txt");
+
+        // clear file contents if it already exists 
+        if (File.Exists(_logFilePath))
+        {
+            File.Delete(_logFilePath);
+        }
+    
+
+    }
+    [TestMethod]
+    public void CreateLogger_CreateLogger_Sucess() 
+    {
+        //arrange
+        
+        
+    
+    }
 }

--- a/Logger.Tests/FileLoggerTests.cs
+++ b/Logger.Tests/FileLoggerTests.cs
@@ -13,19 +13,20 @@ namespace Logger.Tests;
 [TestClass]
 public class FileLoggerTests
 {
-    private string _logFilePath = string.Empty;
+    private string? LogFilePath { get; set; } = "testLogFile.log";
+
 
     [TestInitialize]
     public void Setup()
     {
         //set up logger file path
         string assemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
-        _logFilePath = Path.Combine(assemblyPath, "file.txt");
+        LogFilePath = Path.Combine(assemblyPath, "file.txt");
 
         // clear file contents if it already exists 
-        if (File.Exists(_logFilePath))
+        if (File.Exists(LogFilePath))
         {
-            File.Delete(_logFilePath);
+            File.Delete(LogFilePath);
         }
     
 
@@ -35,12 +36,12 @@ public class FileLoggerTests
     public void Log_AppendMessageInFile_Pass()
     {
         //arrange
-        var fileLogger = new FileLogger(_logFilePath, "testClass");
+        var fileLogger = new FileLogger(LogFilePath, "testClass");
         string testMessage = "Test message";
 
         //act
         fileLogger.Log(LogLevel.Information, testMessage);
-        var logMessage = File.ReadAllText(_logFilePath);
+        var logMessage = File.ReadAllText(LogFilePath!);    // LogFilePath will not be null since it is initialized
         //
         Assert.IsTrue(logMessage.Contains(testMessage));
         Assert.IsTrue(logMessage.Contains("Information"));

--- a/Logger.Tests/FileLoggerTests.cs
+++ b/Logger.Tests/FileLoggerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 using System;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace Logger.Tests;
 
@@ -17,9 +18,9 @@ public class FileLoggerTests
     [TestInitialize]
     public void Setup()
     {
-        //set up loog file path
+        //set up logger file path
         string assemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
-        _logFilePath = Path.Combine(assemblyPath, "testlog.txt");
+        _logFilePath = Path.Combine(assemblyPath, "file.txt");
 
         // clear file contents if it already exists 
         if (File.Exists(_logFilePath))
@@ -29,10 +30,34 @@ public class FileLoggerTests
     
 
     }
-    //[TestMethod]
-    //public string
+    [TestMethod]
+    public void ConfigureFileLogger_FindCorrectFilePath() 
+    {
+        //arrange
+        var logFactory = new LogFactory();
 
+        //act
+        logFactory.ConfigureFileLogger();
 
+        var filePath = typeof(LogFactory).GetProperty("FilePath", BindingFlags.NonPublic | BindingFlags.Instance);
+        var filePathValue = filePath?.GetValue(logFactory) as string;
+        Assert.IsNotNull(filePathValue);
+        Assert.AreEqual(filePathValue, _logFilePath);
+     }
+    [TestMethod]
+    public void Log_AppendMessageInFile()
+    {
+        //arrange
+        var fileLogger = new FileLogger(_logFilePath);
+        string testMessage = "Test message";
 
-  
+        //act
+        fileLogger.Log(LogLevel.Information, testMessage);
+        var logMessage = File.ReadAllText(_logFilePath);
+        //
+        Assert.IsTrue(logMessage.Contains(testMessage));
+        
+    }
+
 }
+

--- a/Logger.Tests/LogFactoryTests.cs
+++ b/Logger.Tests/LogFactoryTests.cs
@@ -10,19 +10,19 @@ namespace Logger.Tests
     public class LogFactoryTests
     {
 
-        private string _logFilePath = string.Empty;
+        private string LogFilePath { get; set; } = string.Empty;
 
         [TestInitialize]
         public void Setup()
         {
             //set up logger file path
             string assemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
-            _logFilePath = Path.Combine(assemblyPath, "file.txt");
+            LogFilePath = Path.Combine(assemblyPath, "file.txt");
 
             // clear file contents if it already exists 
-            if (File.Exists(_logFilePath))
+            if (File.Exists(LogFilePath))
             {
-                File.Delete(_logFilePath);
+                File.Delete(LogFilePath);
             }
         }
         [TestMethod]
@@ -55,7 +55,7 @@ namespace Logger.Tests
 
             //assert
             Assert.IsNotNull(filePathValue);
-            Assert.AreEqual(filePathValue, _logFilePath);
+            Assert.AreEqual(filePathValue, LogFilePath);
         }
 
         [TestMethod]

--- a/Logger.Tests/LogFactoryTests.cs
+++ b/Logger.Tests/LogFactoryTests.cs
@@ -7,7 +7,7 @@ namespace Logger.Tests
     public class LogFactoryTests
     {
         [TestMethod]
-        public void CreateLogger_ReturnFileLogger()
+        public void CreateLogger_CreateFileLogger_Pass()
         {
             // Arrange
             var logFactory = new LogFactory();
@@ -19,6 +19,9 @@ namespace Logger.Tests
             // Assert
             Assert.IsNotNull(logger);
             Assert.IsInstanceOfType(logger, typeof(FileLogger));
+
         }
+
+
     }
 }

--- a/Logger.Tests/LogFactoryTests.cs
+++ b/Logger.Tests/LogFactoryTests.cs
@@ -1,9 +1,24 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Logger.Tests;
-
-[TestClass]
-public class LogFactoryTests
+namespace Logger.Tests
 {
 
+    [TestClass]
+    public class LogFactoryTests
+    {
+        [TestMethod]
+        public void CreateLogger_ReturnFileLogger()
+        {
+            // Arrange
+            var logFactory = new LogFactory();
+            logFactory.ConfigureFileLogger();
+
+            // Act
+            var logger = logFactory.CreateLogger("TestClass");
+
+            // Assert
+            Assert.IsNotNull(logger);
+            Assert.IsInstanceOfType(logger, typeof(FileLogger));
+        }
+    }
 }

--- a/Logger.Tests/Logger.Tests.csproj
+++ b/Logger.Tests/Logger.Tests.csproj
@@ -1,9 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
-		<IsPackable>false</IsPackable>
-		<LangVersion>11.0</LangVersion>
+    <AnalysisLevel>latest-Recommended</AnalysisLevel>
+    
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <LangVersion>11.0</LangVersion>
+    
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Logger.Tests/Logger.Tests.csproj
+++ b/Logger.Tests/Logger.Tests.csproj
@@ -5,7 +5,7 @@
     
     <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>11.0</LangVersion>
+    
     
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/Logger/BaseLogger.cs
+++ b/Logger/BaseLogger.cs
@@ -2,6 +2,8 @@
 
 public abstract class BaseLogger
 {
+    public string? ClassName { get; set; }
+
     public abstract void Log(LogLevel logLevel, string message);
 }
 

--- a/Logger/BaseLogger.cs
+++ b/Logger/BaseLogger.cs
@@ -4,6 +4,7 @@ public abstract class BaseLogger
 {
     public string? ClassName { get; set; }
 
+    //Simple Constructer for BaseLogger
     public abstract void Log(LogLevel logLevel, string message);
 }
 

--- a/Logger/BaseLoggerMixins.cs
+++ b/Logger/BaseLoggerMixins.cs
@@ -1,6 +1,56 @@
-﻿namespace Logger;
+﻿using System;
 
+namespace Logger;
+
+// Implements Extension methods for the four LogLevels
 public static class BaseLoggerMixins
 {
+    //  Each of these methods should take in a `string` for the message, as well as a
+    //  **parameter array** of arguments for the message.
+    //  Each of these extension methods is expected to be a shortcut for calling the
+    //  `BaseLogger.Log` method, by automatically supplying the appropriate `LogLevel`.
+    //  These methods should throw an exception if the `BaseLogger` parameter is null.
+    //  There are a couple example unit tests to get you started.
+
+    //private static BaseLogger Logger { get; } = new FileLogger();
+    
+    // Error
+    public static void Error(this BaseLogger? Logger, string message, params string[] args)
+    {
+        // Throw Exception if BaseLogger param is null
+        ArgumentNullException.ThrowIfNull(Logger);
+
+        // Call BaseLogger.Log passing in the Error LogLevel
+
+
+        Logger.Log(LogLevel.Error, message);
+    }
+
+    // Warning
+    public static void Warning(this BaseLogger? Logger, string message, params string[] args)
+    {
+        // Throw Exception if BaseLogger param is null
+        ArgumentNullException.ThrowIfNull(Logger);
+
+        Logger.Log(LogLevel.Warning, message);
+    }
+
+    // Information
+    public static void Information(this BaseLogger? Logger, string message, params string[] args)
+    {
+        // Throw Exception if BaseLogger param is null
+        ArgumentNullException.ThrowIfNull(Logger);
+
+        Logger.Log(LogLevel.Information, message);
+    }
+
+    // Debug
+    public static void Debug(this BaseLogger? Logger, string message, params string[] args)
+    {
+        // Throw Exception if BaseLogger param is null
+        ArgumentNullException.ThrowIfNull(Logger);
+
+        Logger.Log(LogLevel.Debug, message);
+    }
 
 }

--- a/Logger/BaseLoggerMixins.cs
+++ b/Logger/BaseLoggerMixins.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Logger;
 
@@ -20,9 +21,10 @@ public static class BaseLoggerMixins
         // Throw Exception if BaseLogger param is null
         ArgumentNullException.ThrowIfNull(logger);
 
-        string? newMessage = string.Format(message, args);
+        string? newMessage = string.Format(CultureInfo.InvariantCulture, message, args);
+
         // Call to Log method passing in the Error LogLevel     
-        logger.Log(LogLevel.Error, message);
+        logger.Log(LogLevel.Error, newMessage);
     }
 
 
@@ -32,8 +34,10 @@ public static class BaseLoggerMixins
         // Throw Exception if BaseLogger param is null
         ArgumentNullException.ThrowIfNull(logger);
 
+        string? newMessage = string.Format(CultureInfo.InvariantCulture, message, args);
+
         // Call to Log method passing in the Warning LogLevel     
-        logger.Log(LogLevel.Warning, message);
+        logger.Log(LogLevel.Warning, newMessage);
     }
 
 
@@ -43,8 +47,10 @@ public static class BaseLoggerMixins
         // Throw Exception if BaseLogger param is null
         ArgumentNullException.ThrowIfNull(logger);
 
+        string? newMessage = string.Format(CultureInfo.InvariantCulture, message, args);
+
         // Call to Log method passing in the Information LogLevel
-        logger.Log(LogLevel.Information, message);
+        logger.Log(LogLevel.Information, newMessage);
     }
 
 
@@ -54,7 +60,9 @@ public static class BaseLoggerMixins
         // Throw Exception if BaseLogger param is null
         ArgumentNullException.ThrowIfNull(logger);
 
+        string? newMessage = string.Format(CultureInfo.InvariantCulture, message, args);
+
         // Call to Log method passing in the Debug LogLevel
-        logger.Log(LogLevel.Debug, message);
+        logger.Log(LogLevel.Debug, newMessage);
     }
 }

--- a/Logger/BaseLoggerMixins.cs
+++ b/Logger/BaseLoggerMixins.cs
@@ -15,42 +15,46 @@ public static class BaseLoggerMixins
     //private static BaseLogger Logger { get; } = new FileLogger();
     
     // Error extension method
-    public static void Error(this BaseLogger? logger, string message, params string[] args)
+    public static void Error(this BaseLogger? logger, string message, params object[] args)
     {
         // Throw Exception if BaseLogger param is null
         ArgumentNullException.ThrowIfNull(logger);
 
-        // Call BaseLogger.Log passing in the Error LogLevel
-        
-
+        string? newMessage = string.Format(message, args);
+        // Call to Log method passing in the Error LogLevel     
         logger.Log(LogLevel.Error, message);
     }
 
+
     // Warning extension method
-    public static void Warning(this BaseLogger? logger, string message, params string[] args)
+    public static void Warning(this BaseLogger? logger, string message, params object[] args)
     {
         // Throw Exception if BaseLogger param is null
         ArgumentNullException.ThrowIfNull(logger);
 
+        // Call to Log method passing in the Warning LogLevel     
         logger.Log(LogLevel.Warning, message);
     }
 
+
     // Information extension method
-    public static void Information(this BaseLogger? logger, string message, params string[] args)
+    public static void Information(this BaseLogger? logger, string message, params object[] args)
     {
         // Throw Exception if BaseLogger param is null
         ArgumentNullException.ThrowIfNull(logger);
 
+        // Call to Log method passing in the Information LogLevel
         logger.Log(LogLevel.Information, message);
     }
 
+
     // Debug extension method
-    public static void Debug(this BaseLogger? logger, string message, params string[] args)
+    public static void Debug(this BaseLogger? logger, string message, params object[] args)
     {
         // Throw Exception if BaseLogger param is null
         ArgumentNullException.ThrowIfNull(logger);
 
+        // Call to Log method passing in the Debug LogLevel
         logger.Log(LogLevel.Debug, message);
     }
-
 }

--- a/Logger/BaseLoggerMixins.cs
+++ b/Logger/BaseLoggerMixins.cs
@@ -14,43 +14,43 @@ public static class BaseLoggerMixins
 
     //private static BaseLogger Logger { get; } = new FileLogger();
     
-    // Error
-    public static void Error(this BaseLogger? Logger, string message, params string[] args)
+    // Error extension method
+    public static void Error(this BaseLogger? logger, string message, params string[] args)
     {
         // Throw Exception if BaseLogger param is null
-        ArgumentNullException.ThrowIfNull(Logger);
+        ArgumentNullException.ThrowIfNull(logger);
 
         // Call BaseLogger.Log passing in the Error LogLevel
+        
 
-
-        Logger.Log(LogLevel.Error, message);
+        logger.Log(LogLevel.Error, message);
     }
 
-    // Warning
-    public static void Warning(this BaseLogger? Logger, string message, params string[] args)
+    // Warning extension method
+    public static void Warning(this BaseLogger? logger, string message, params string[] args)
     {
         // Throw Exception if BaseLogger param is null
-        ArgumentNullException.ThrowIfNull(Logger);
+        ArgumentNullException.ThrowIfNull(logger);
 
-        Logger.Log(LogLevel.Warning, message);
+        logger.Log(LogLevel.Warning, message);
     }
 
-    // Information
-    public static void Information(this BaseLogger? Logger, string message, params string[] args)
+    // Information extension method
+    public static void Information(this BaseLogger? logger, string message, params string[] args)
     {
         // Throw Exception if BaseLogger param is null
-        ArgumentNullException.ThrowIfNull(Logger);
+        ArgumentNullException.ThrowIfNull(logger);
 
-        Logger.Log(LogLevel.Information, message);
+        logger.Log(LogLevel.Information, message);
     }
 
-    // Debug
-    public static void Debug(this BaseLogger? Logger, string message, params string[] args)
+    // Debug extension method
+    public static void Debug(this BaseLogger? logger, string message, params string[] args)
     {
         // Throw Exception if BaseLogger param is null
-        ArgumentNullException.ThrowIfNull(Logger);
+        ArgumentNullException.ThrowIfNull(logger);
 
-        Logger.Log(LogLevel.Debug, message);
+        logger.Log(LogLevel.Debug, message);
     }
 
 }

--- a/Logger/BaseLoggerMixins.cs
+++ b/Logger/BaseLoggerMixins.cs
@@ -21,10 +21,8 @@ public static class BaseLoggerMixins
         // Throw Exception if BaseLogger param is null
         ArgumentNullException.ThrowIfNull(logger);
 
-        string? newMessage = string.Format(CultureInfo.InvariantCulture, message, args);
-
         // Call to Log method passing in the Error LogLevel     
-        logger.Log(LogLevel.Error, newMessage);
+        logger.Log(LogLevel.Error, string.Format(CultureInfo.InvariantCulture, message, args));
     }
 
 
@@ -34,10 +32,8 @@ public static class BaseLoggerMixins
         // Throw Exception if BaseLogger param is null
         ArgumentNullException.ThrowIfNull(logger);
 
-        string? newMessage = string.Format(CultureInfo.InvariantCulture, message, args);
-
         // Call to Log method passing in the Warning LogLevel     
-        logger.Log(LogLevel.Warning, newMessage);
+        logger.Log(LogLevel.Warning, string.Format(CultureInfo.InvariantCulture, message, args));
     }
 
 
@@ -47,10 +43,8 @@ public static class BaseLoggerMixins
         // Throw Exception if BaseLogger param is null
         ArgumentNullException.ThrowIfNull(logger);
 
-        string? newMessage = string.Format(CultureInfo.InvariantCulture, message, args);
-
-        // Call to Log method passing in the Information LogLevel
-        logger.Log(LogLevel.Information, newMessage);
+        // Call to Log method passing in the Information LogLevel     
+        logger.Log(LogLevel.Information, string.Format(CultureInfo.InvariantCulture, message, args));
     }
 
 
@@ -60,9 +54,7 @@ public static class BaseLoggerMixins
         // Throw Exception if BaseLogger param is null
         ArgumentNullException.ThrowIfNull(logger);
 
-        string? newMessage = string.Format(CultureInfo.InvariantCulture, message, args);
-
-        // Call to Log method passing in the Debug LogLevel
-        logger.Log(LogLevel.Debug, newMessage);
+        // Call to Log method passing in the Debug LogLevel     
+        logger.Log(LogLevel.Debug, string.Format(CultureInfo.InvariantCulture, message, args));
     }
 }

--- a/Logger/FileLogger.cs
+++ b/Logger/FileLogger.cs
@@ -8,21 +8,20 @@ namespace Logger
 {
     public class FileLogger : BaseLogger
     {
-        private readonly string _filePath;
-       
+        private string FilePath { get; }
 
         public FileLogger(string? filePath, string className)
         {
-            _filePath = filePath ?? throw new ArgumentNullException(nameof(filePath), "FilePath cannot be Null.");
-            _filePath = filePath;
+            FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath), "FilePath cannot be Null.");
+            FilePath = filePath;
             ClassName = className;
         }
-       
+
 
         public override void Log(LogLevel logLevel, string message)
         {
             var logAppend = $"{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture)} {ClassName} {logLevel}: {message}{Environment.NewLine}";
-            File.AppendAllText(_filePath, logAppend);
+            File.AppendAllText(FilePath, logAppend);
         }
     }
 

--- a/Logger/FileLogger.cs
+++ b/Logger/FileLogger.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
+using System.Reflection.Emit;
 
 namespace Logger
 {
@@ -16,7 +18,9 @@ namespace Logger
 
         public override void Log(LogLevel logLevel, string message)
         {
-            throw new NotImplementedException();
+            var logAppend = $"{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture)} {ClassName} {logLevel}: {message}{Environment.NewLine}";
+            File.AppendAllText(_filePath, logAppend);
+            Console.WriteLine(logAppend);
         }
     }
 

--- a/Logger/FileLogger.cs
+++ b/Logger/FileLogger.cs
@@ -9,10 +9,12 @@ namespace Logger
     public class FileLogger : BaseLogger
     {
         private readonly string _filePath;
+       
 
-        public FileLogger(string filePath)
+        public FileLogger(string filePath, string className)
         {
             _filePath = filePath;
+            ClassName = className;
         }
        
 
@@ -20,7 +22,6 @@ namespace Logger
         {
             var logAppend = $"{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture)} {ClassName} {logLevel}: {message}{Environment.NewLine}";
             File.AppendAllText(_filePath, logAppend);
-            Console.WriteLine(logAppend);
         }
     }
 

--- a/Logger/FileLogger.cs
+++ b/Logger/FileLogger.cs
@@ -8,6 +8,7 @@ namespace Logger
 {
     public class FileLogger : BaseLogger
     {
+        
         private string FilePath { get; }
 
         public FileLogger(string? filePath, string className)
@@ -17,7 +18,7 @@ namespace Logger
             ClassName = className;
         }
 
-
+        //Creates and Appends Log Message to file.txt
         public override void Log(LogLevel logLevel, string message)
         {
             var logAppend = $"{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture)} {ClassName} {logLevel}: {message}{Environment.NewLine}";

--- a/Logger/FileLogger.cs
+++ b/Logger/FileLogger.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+
+namespace Logger
+{
+    public class FileLogger : BaseLogger
+    {
+        private readonly string _filePath;
+
+        public FileLogger(string filePath)
+        {
+            _filePath = filePath;
+        }
+       
+
+        public override void Log(LogLevel logLevel, string message)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+
+}

--- a/Logger/LogFactory.cs
+++ b/Logger/LogFactory.cs
@@ -7,7 +7,7 @@ namespace Logger;
 public class LogFactory
 {
 
-    public string? FilePath { get; private set; }
+    private string? FilePath { get; set; }
 
     public void ConfigureFileLogger()
     {
@@ -15,7 +15,7 @@ public class LogFactory
         string assemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
         FilePath = Path.Combine(assemblyPath, "file.txt");
     }
-
+    // Creates Logger unless File Path is Null
     public BaseLogger? CreateLogger(string? className)
     {
         if (string.IsNullOrEmpty(FilePath))

--- a/Logger/LogFactory.cs
+++ b/Logger/LogFactory.cs
@@ -1,10 +1,27 @@
-﻿namespace Logger;
+﻿using System;
+using System.IO;
+using System.Reflection;
+
+namespace Logger;
 
 public class LogFactory
 {
-    public BaseLogger CreateLogger(string className)
-    {
 
-        return null;
+    private string? FilePath {get; set;}
+
+    public void ConfigureFileLogger()
+    {
+        // Get assembaly Path and combine with txt file
+        string assemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
+        FilePath = Path.Combine(assemblyPath, "file.txt");
+    }
+
+    public BaseLogger? CreateLogger(string className)
+    {
+        if (string.IsNullOrEmpty(FilePath))
+        {
+            return null;
+        }
+        return new FileLogger(FilePath) { ClassName = className };
     }
 }

--- a/Logger/LogFactory.cs
+++ b/Logger/LogFactory.cs
@@ -22,6 +22,6 @@ public class LogFactory
         {
             return null;
         }
-        return new FileLogger(FilePath) { ClassName = className };
+        return new FileLogger(FilePath, className);
     }
 }

--- a/Logger/LogFactory.cs
+++ b/Logger/LogFactory.cs
@@ -7,11 +7,11 @@ namespace Logger;
 public class LogFactory
 {
 
-    private string? FilePath {get; set;}
+    public string? FilePath { get; private set; }
 
     public void ConfigureFileLogger()
     {
-        // Get assembaly Path and combine with txt file
+        // Get assembly Path and combine with txt file
         string assemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
         FilePath = Path.Combine(assemblyPath, "file.txt");
     }

--- a/Logger/LogLevel.cs
+++ b/Logger/LogLevel.cs
@@ -1,5 +1,6 @@
 ﻿namespace Logger;
 
+// Enums for BaceLoggerMixins
 public enum LogLevel
 {
     Error,

--- a/Logger/Logger.csproj
+++ b/Logger/Logger.csproj
@@ -5,7 +5,7 @@
     
     <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>11.0</LangVersion>
+    
     
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/Logger/Logger.csproj
+++ b/Logger/Logger.csproj
@@ -1,8 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <AnalysisLevel>latest-Recommended</AnalysisLevel>
+    
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
     <LangVersion>11.0</LangVersion>
+    
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    
   </PropertyGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Read **Chapters 4-6** with an **especially careful read of Chapter 6**. Pay spec
 - There is an existing `BaseLogger` class. It needs an **auto property** to hold a class name. This property should be set in the `LogFactory` using an **object initializer**. ✔
 - Create a `FileLogger` that derives from `BaseLogger`. It should take in a path to a file to write the log message to. When its `Log` method is called, it should **append** messages on their own line in the file. The output should include all of the following:
   - The current date/time ✔
-  - The name of the class that created the logger ❌✔
+  - The name of the class that created the logger ✔
   - The log level ✔
   - The message ✔
   - The format may vary, but an example might look like this "10/7/2019 12:38:59 AM FileLoggerTests Warning: Test message"

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Read **Chapters 4-6** with an **especially careful read of Chapter 6**. Pay spec
 
 ## Assignment
 
-- There is an existing `BaseLogger` class. It needs an **auto property** to hold a class name. This property should be set in the `LogFactory` using an **object initializer**. ❌✔
+- There is an existing `BaseLogger` class. It needs an **auto property** to hold a class name. This property should be set in the `LogFactory` using an **object initializer**. ✔
 - Create a `FileLogger` that derives from `BaseLogger`. It should take in a path to a file to write the log message to. When its `Log` method is called, it should **append** messages on their own line in the file. The output should include all of the following:
-  - The current date/time ❌✔
+  - The current date/time ❌✔ //File Logger Made Needs to Append messages
   - The name of the class that created the logger ❌✔
   - The log level ❌✔
   - The message ❌✔
@@ -23,15 +23,15 @@ Read **Chapters 4-6** with an **especially careful read of Chapter 6**. Pay spec
   - `Error`, ❌✔
   - `Warning`, ❌✔
   - `Information`, and ❌✔
-  - `Debug`. ❌✔
+  - `Debug`. ❌✔ //Can You Work On These
   Each of these methods should take in a `string` for the message, as well as a **parameter array** of arguments for the message. Each of these extension methods is expected to be a shortcut for calling the `BaseLogger.Log` method, by automatically supplying the appropriate `LogLevel`. These methods should throw an exception if the `BaseLogger` parameter is null. There are a couple example unit tests to get you started.
 - Use the nameof() operator when identifying the class name to the logger ❌✔
 - Ensure you turn on Warnings as Errors (TreatWarningsAsErrors) ✔
 - Ensure that you turn on code analysis (EnableNETAnalyzers) ✔
 - Ensure that you turn on CodeAnalysisTreatWarningsAsErrors ✔
 - Ensure that you turn on EnforceCodeStyleInBuild ✔
-- Set `LangVersion` and the `TargetFramework` to the latest released versions available (preview versions optional) ❌✔
-- Turn on Nullability (`Nullable`) ❌✔
+- Set `LangVersion` and the `TargetFramework` to the latest released versions available (preview versions optional) ✔
+- Turn on Nullability (`Nullable`) ✔
 - **All of the above should be unit tested.**
 
 ## Extra Credit

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Read **Chapters 4-6** with an **especially careful read of Chapter 6**. Pay spec
   - `Debug`. ❌✔
   Each of these methods should take in a `string` for the message, as well as a **parameter array** of arguments for the message. Each of these extension methods is expected to be a shortcut for calling the `BaseLogger.Log` method, by automatically supplying the appropriate `LogLevel`. These methods should throw an exception if the `BaseLogger` parameter is null. There are a couple example unit tests to get you started.
 - Use the nameof() operator when identifying the class name to the logger ❌✔
-- Ensure you turn on Warnings as Errors (TreatWarningsAsErrors) ❌✔
-- Ensure that you turn on code analysis (EnableNETAnalyzers) ❌✔
-- Ensure that you turn on CodeAnalysisTreatWarningsAsErrors ❌✔
-- Ensure that you turn on EnforceCodeStyleInBuild ❌✔
+- Ensure you turn on Warnings as Errors (TreatWarningsAsErrors) ✔
+- Ensure that you turn on code analysis (EnableNETAnalyzers) ✔
+- Ensure that you turn on CodeAnalysisTreatWarningsAsErrors ✔
+- Ensure that you turn on EnforceCodeStyleInBuild ✔
 - Set `LangVersion` and the `TargetFramework` to the latest released versions available (preview versions optional) ❌✔
 - Turn on Nullability (`Nullable`) ❌✔
 - **All of the above should be unit tested.**

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Read **Chapters 4-6** with an **especially careful read of Chapter 6**. Pay spec
 
 - There is an existing `BaseLogger` class. It needs an **auto property** to hold a class name. This property should be set in the `LogFactory` using an **object initializer**. ✔
 - Create a `FileLogger` that derives from `BaseLogger`. It should take in a path to a file to write the log message to. When its `Log` method is called, it should **append** messages on their own line in the file. The output should include all of the following:
-  - The current date/time ❌✔ //File Logger Made Needs to Append messages
+  - The current date/time ✔
   - The name of the class that created the logger ❌✔
-  - The log level ❌✔
-  - The message ❌✔
+  - The log level ✔
+  - The message ✔
   - The format may vary, but an example might look like this "10/7/2019 12:38:59 AM FileLoggerTests Warning: Test message"
-- The `LogFactory` should be updated with a new method `ConfigureFileLogger`. This should take in a file path and store it in a **private member**. It should use this when instantiating a new `FileLogger` in its `CreateLogger` method. ❌✔
+- The `LogFactory` should be updated with a new method `ConfigureFileLogger`. This should take in a file path and store it in a **private member**. It should use this when instantiating a new `FileLogger` in its `CreateLogger` method. ✔
 - If the file logger has not be configured in the `LogFactory`, its `CreateLogger` method should return `null`. ❌✔
 - Inside of `BaseLoggerMixins` implement **extension methods** on `BaseLogger` for
   - `Error`, ❌✔


### PR DESCRIPTION
## Assignment

- There is an existing `BaseLogger` class. It needs an **auto property** to hold a class name. This property should be set in the `LogFactory` using an **object initializer**. ✔
- Create a `FileLogger` that derives from `BaseLogger`. It should take in a path to a file to write the log message to. When its `Log` method is called, it should **append** messages on their own line in the file. The output should include all of the following:
  - The current date/time ✔
  - The name of the class that created the logger ✔
  - The log level ✔
  - The message ✔
  - The format may vary, but an example might look like this "10/7/2019 12:38:59 AM FileLoggerTests Warning: Test message"
- The `LogFactory` should be updated with a new method `ConfigureFileLogger`. This should take in a file path and store it in a **private member**. It should use this when instantiating a new `FileLogger` in its `CreateLogger` method. ✔
- If the file logger has not be configured in the `LogFactory`, its `CreateLogger` method should return `null`. ✔
- Inside of `BaseLoggerMixins` implement **extension methods** on `BaseLogger` for
  - `Error`, ✔
  - `Warning`, ✔
  - `Information`, and ✔
  - `Debug`. ✔ 
  Each of these methods should take in a `string` for the message, as well as a **parameter array** of arguments for the message. Each of these extension methods is expected to be a shortcut for calling the `BaseLogger.Log` method, by automatically supplying the appropriate `LogLevel`. These methods should throw an exception if the `BaseLogger` parameter is null. There are a couple example unit tests to get you started.
- Use the nameof() operator when identifying the class name to the logger ❌✔
- Ensure you turn on Warnings as Errors (TreatWarningsAsErrors) ✔
- Ensure that you turn on code analysis (EnableNETAnalyzers) ✔
- Ensure that you turn on CodeAnalysisTreatWarningsAsErrors ✔
- Ensure that you turn on EnforceCodeStyleInBuild ✔
- Set `LangVersion` and the `TargetFramework` to the latest released versions available (preview versions optional) ✔
- Turn on Nullability (`Nullable`) ✔
- **All of the above should be unit tested.**

## Extra Credit

- Implement an additional logger. This logger must be unit tested. Some options to consider could be one that uses `System.Console` or `System.Diagnostics.Trace` ❌✔
- Implement the factory pattern using static abstract methods on a Logger interface instead.